### PR TITLE
Fix a package load exception because the project is not registered as a MEF component.

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -18,6 +18,7 @@
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
 </PackageManifest>
 


### PR DESCRIPTION
As a result, the exported components cannot be found during package loading thus the addon isn't functioning.